### PR TITLE
chore: provider charts chart-source-of-truth updates

### DIFF
--- a/migrations/Chart/R1_01_UpdateSourceOfTruthProviderCharts.sql
+++ b/migrations/Chart/R1_01_UpdateSourceOfTruthProviderCharts.sql
@@ -1,0 +1,6 @@
+-- Rollback script for V1_01_UpdateSourceOfTruthProviderCharts
+UPDATE public."ChartsSourceOfTruth"
+SET "Type" = 'option'
+WHERE "Type" = 'cross-option'
+  AND "ChartType" = 'provider'
+  AND "ChartSectionId" IN ('SPRO2', 'SRAD', 'SDIS', 'SPSN2');

--- a/migrations/Chart/V1_01_CreateAuditReviewColumn.sql
+++ b/migrations/Chart/V1_01_CreateAuditReviewColumn.sql
@@ -1,4 +1,4 @@
--- # Created At: 13-05-2025
+-- # Created At: 19-05-2025
 -- # Description: The following columns will be used for storing the review value of a section and subsection
 -- # Related to: EN-2691
 

--- a/migrations/Chart/V1_01_UpdateSourceOfTruthProviderCharts.sql
+++ b/migrations/Chart/V1_01_UpdateSourceOfTruthProviderCharts.sql
@@ -1,0 +1,14 @@
+-- # Created At: 20-05-2025
+-- # Description: Updates "Type" from 'option' to 'cross-option' in ChartsSourceOfTruth for specific ChartSectionIds
+-- # Related to: EN-2704
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'ChartsSourceOfTruth') THEN
+        UPDATE public."ChartsSourceOfTruth"
+        SET "Type" = 'cross-option'
+        WHERE "Type" = 'option'
+          AND "ChartType" = 'Provider'
+          AND "ChartSectionId" IN ('SPRO2', 'SRAD', 'SDIS', 'SPSN2');
+    END IF;
+END $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description
- Added new migration and rollback for the ChartsSourceOfTruth table for the following provider sections:
  - SPRO2
  - SRAD
  - SDIS
  - SPSN2